### PR TITLE
changed functionality to draw a quiver plot

### DIFF
--- a/plotter/plotter_serial.py
+++ b/plotter/plotter_serial.py
@@ -64,11 +64,19 @@ while True:
         ys.pop(0)
         zs.pop(0)
         cs.pop(0)
+        
+    # create a position vector for plotting the vectors
+    # since our buffer is 256, make that the max length of the vector
+    # we could draw these in a circle if we knew how many samples were in a rotation, or what the magnet position was, but a line will do
+    xx = range(len(xs))
+    yy = [0] * len(xs)
+    zz = [0] * len(xs)
+    
 
     # draw when we have 2 points, too frequent draws cause lags    
     if new_points_count > 1:
         ax.cla()
-        ax.scatter(xs, ys, zs, c=cs, cmap='cool')
+        ax.quiver(xx, yy, zz, xs, ys, zs, c=cs, cmap='cool')
         new_points_count = 0
 
     plt.draw()


### PR DESCRIPTION
This update should generate the required matrices for a 3d quiver plot and then plot the vectors in a line along x up to 256 points long.

I'd recommend figuring out some way to rotate the device at a fixed rate if you wanted to plot the field vectors more spatially accurately.

One other suggestion, to address the latency when plotting, is to instead of calling the quiver/scatter function for each frame, update the data objects for your plots. This avoids redrawing the entire axis. I *think* this functionality exists in the 3d plots in MPL, as I know it exists in the 2d versions.